### PR TITLE
feat: 공통 레이아웃 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,24 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import ErrorPage from './pages/ErrorPage';
 import SignUpPage from './pages/auth/SignUpPage';
 import RankingPage from './pages/RankingPage';
 import NotificationPage from './pages/NotificationPage';
 import MyPage from './pages/MyPage';
+import Overlay from './components/common/Overlay';
 
 function App() {
 	return (
-		<BrowserRouter>
+		<Overlay>
 			<Routes>
-				<Route path="/" element={<HomePage/>} />
-				<Route path="/not-found" element={<ErrorPage/>}/>
-				<Route path="/sign-up/" element={<SignUpPage/>}/>
-				<Route path="/main/ranking" element={<RankingPage/>}/>
-				<Route path="/main/notification" element={<NotificationPage/>}/>
-				<Route path="/main/my-page" element={<MyPage/>}/>
+				<Route path="/" element={<HomePage />} />
+				<Route path="/not-found" element={<ErrorPage />} />
+				<Route path="/sign-up/" element={<SignUpPage />} />
+				<Route path="/main/ranking" element={<RankingPage />} />
+				<Route path="/main/notification" element={<NotificationPage />} />
+				<Route path="/main/my-page" element={<MyPage />} />
 			</Routes>
-		</BrowserRouter>
+		</Overlay>
 	);
 }
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { useNavigate, useRoutes } from 'react-router-dom';
-import subLogo from '../../../assets/images/sub_logo.png';
+import { useNavigate } from 'react-router-dom';
+import subLogo from '../../assets/images/sub_logo.png';
 
 export default function Header() {
     const labels = [

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { useNavigate, useRoutes } from 'react-router-dom';
+import subLogo from '../../../assets/images/sub_logo.png';
+
+export default function Header() {
+    const labels = [
+        { title: '알림', path: '/main/notification' },
+        { title: '랭킹', path: '/main/ranking' },
+        { title: '마이페이지', path: '/main/my-page' },
+    ];
+    const nav = useNavigate();
+    const [active, setActive] = useState('랭킹');
+
+    //전환 버튼 클릭 시
+    const handleClick = (title: string, path: string) => {
+        setActive(title);
+        nav(path);
+    };
+
+    //로고 클릭 시 -> /main/ranking으로 이동
+    const handleClickHome = () => {
+        nav('/main/ranking');
+        setActive('랭킹');
+    };
+
+    return (
+        <header className="w-full fixed top-0 h-20 flex items-center bg-white border-b border-gray-200 px-4">
+            {/* 로고 이미지 */}
+            <div className="flex-1 flex items-center">
+                <img src={subLogo} alt="로고 이지미" onClick={handleClickHome} className="cursor-pointer" />
+            </div>
+
+            {/* 페이지 전환 바 */}
+            <ul className="flex justify-center items-center bg-gray-300 rounded-lg py-1 px-2 gap-2 max-w-[680px] mx-auto">
+                {labels.map(({ title, path }) => (
+                    <li
+                        key={title}
+                        onClick={() => handleClick(title, path)}
+                        className={`
+              w-32 py-2 text-center text-sm font-medium rounded-lg cursor-pointer transition-all duration-300 ease-in-out
+              ${active === title ? 'bg-white shadow-xl text-black-200 scale-[1.1]' : 'bg-transparent scale-100 text-gray-500'}
+            `}>
+                        {title}
+                    </li>
+                ))}
+            </ul>
+            <div className="flex-1 flex"></div>
+        </header>
+    );
+}

--- a/src/components/common/Overlay.tsx
+++ b/src/components/common/Overlay.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router-dom';
+import Header from './Header';
+
+/**
+ * 통합 레이아웃
+ * @returns
+ */
+export default function Overlay({ children }: { children: React.ReactNode }) {
+    const location = useLocation();
+    const showHeader = location.pathname.startsWith('/main');
+
+    return (
+        <div
+            className={
+                showHeader
+                    ? 'flex justify-center items-center min-h-[calc(100vh-5rem)] pt-20'
+                    : 'flex justify-center items-center min-h-screen'
+            }>
+            {showHeader && <Header />}
+            <main className={`${showHeader ? 'pt-20' : ''} flex flex-col justify-center items-center`}>
+                {children}
+            </main>
+        </div>
+    );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,9 @@
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
-import './index.css'
-createRoot(document.getElementById('root')!).render(<App />);
+import './index.css';
+createRoot(document.getElementById('root')!).render(
+	<BrowserRouter>
+		<App />
+	</BrowserRouter>,
+);


### PR DESCRIPTION
## 🍀 이슈 번호

- #1

---

## ✅ 작업 사항

### 공통헤더

<img width="1920" height="1201" alt="스크린샷 2025-12-04 14 58 59" src="https://github.com/user-attachments/assets/5381a831-675c-4abf-9252-abfa5268b9c8" />

1. 첨부한 사진과 같이 공통 `header` 컴포넌트 구현했습니다.
2. `page` 라우팅 주소 기준으로 `/main/**` 에 해당하는 모든 페이지에 `header`가 나타나도록 구현했습니다.

```javascript
const showHeader = location.pathname.startsWith('/main');

<div
            className={
                showHeader
                    ? 'flex justify-center items-center min-h-[calc(100vh-5rem)] pt-20'
                    : 'flex justify-center items-center min-h-screen'
            }>
            {showHeader && <Header />}
            
         ...

 </div>
```
3. showHeader 변수를 사용해 조건부 렌더링 형식으로 구현했습니다.

---

### 공통 레이아웃

1. `Overlay.tsx`를 따로 구현하여 모든 페이지에 대해 수직 및 수평 중앙 정렬과 flex 속성을 추가했습니다.
2. 참고) 수직 정렬을 사용하지 않는 페이지에서는 `flex-row` 설정을 추가해주세요.

---

## ⌨ 기타

### 공통 색상 주입

- 루트 디렉토리에 tailwindcss.config에 피그마 기준으로 사용된 모든 색상을 등록해놨습니다. 사용방법은 아래와 같습니다.

```html
<header className="border-gray-200"></header>
```

- css 작성 같은 경우 인라인 형식으로 `tailwindcss` 라이브러리를 사용하는 것을 권장합니다.
- 공식문서 :[tailwindcss 공식문서]( https://tailwindcss.com/docs/aspect-ratio)

