### PR TITLE
feat: Slack 소셜 로그인 api 바인딩 작업 진행

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
 import ErrorPage from './pages/ErrorPage';
-import SignUpPage from './pages/auth/SignUpPage';
+import SignUpPage from '@/pages/auth/SignUpPage';
 import RankingPage from './pages/RankingPage';
 import NotificationPage from './pages/NotificationPage';
 import MyPage from './pages/MyPage';
 import Overlay from './components/common/Overlay';
 import LoginPage from './pages/auth/LoginPage';
-import SlackCallbackPage from './pages/auth/SlackCallbackPage';
+import SlackCallbackPage from '@/pages/auth/SlackCallbackPage';
 
 function App() {
 	return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import NotificationPage from './pages/NotificationPage';
 import MyPage from './pages/MyPage';
 import Overlay from './components/common/Overlay';
 import LoginPage from './pages/auth/LoginPage';
+import SlackCallbackPage from './pages/auth/SlackCallbackPage';
 
 function App() {
 	return (
@@ -17,6 +18,8 @@ function App() {
 				<Route path="/main/ranking" element={<RankingPage />} />
 				<Route path="/main/notification" element={<NotificationPage />} />
 				<Route path="/main/my-page" element={<MyPage />} />
+
+				<Route path="/oauth/slack/callback" element={<SlackCallbackPage />} />
 			</Routes>
 		</Overlay>
 	);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,47 @@
+export interface ApiReponse<T> {
+    success: boolean;
+    errorCode: string | null;
+    message: string;
+    data: T;
+}
+
+export async function apiFetch<T>(
+    path: string,
+    options: RequestInit = {}
+): Promise<ApiReponse<T>> {
+    const accessToken = localStorage.getItem("accessToken");
+
+    const headers = new Headers(options.headers ?? {});
+    headers.set("Content-Type", "application/json");
+
+    if (accessToken) {
+        headers.set("Authorization", `Bearer ${accessToken}`);
+    }
+
+    const url = path
+    
+    const res = await fetch(url, {
+        ...options,
+        headers,
+    });
+
+    const body: ApiReponse<T> = await res.json();
+
+    if (body.success) return body;
+
+    switch (body.errorCode) {
+        case "AUTH_004": // ACCESS TOKEN EXPIRED
+            localStorage.clear();
+            window.location.href = "/";
+            throw new Error("ACCESS_TOKEN_EXPIRED");
+
+        case "AUTH_005": // REFRESH TOKEN EXPIRED
+        case "AUTH_007": // REFRESH TOKEN MISMATCH
+            localStorage.clear();
+            window.location.href = "/";
+            throw new Error("REFRESH_TOKEN_EXPIRED");
+
+        default:
+            throw new Error(body.errorCode ?? "UNKNOWN_ERROR");
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-export interface ApiReponse<T> {
+export interface ApiResponse<T> {
     success: boolean;
     errorCode: string | null;
     message: string;
@@ -8,7 +8,7 @@ export interface ApiReponse<T> {
 export async function apiFetch<T>(
     path: string,
     options: RequestInit = {}
-): Promise<ApiReponse<T>> {
+): Promise<ApiResponse<T>> {
     const accessToken = localStorage.getItem("accessToken");
 
     const headers = new Headers(options.headers ?? {});
@@ -25,7 +25,7 @@ export async function apiFetch<T>(
         headers,
     });
 
-    const body: ApiReponse<T> = await res.json();
+    const body: ApiResponse<T> = await res.json();
 
     if (body.success) return body;
 

--- a/src/components/signup/SlackLoginButton.tsx
+++ b/src/components/signup/SlackLoginButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import slackLogo from "../../assets/images/slack.png";
+import slackLogo from "@/assets/images/slack.png";
 
 interface Props {
   onClick: () => void;

--- a/src/components/signup/TeamDropDown.tsx
+++ b/src/components/signup/TeamDropDown.tsx
@@ -13,7 +13,8 @@ export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProp
     <div className="relative w-full">
 
       {/* 선택박스 */}
-      <div
+      <button
+        type="button"
         onClick={() => setOpen(!open)}
         className="w-full h-[45px] border border-[#DADCE0] rounded-[8px]
         px-3 flex items-center justify-between cursor-pointer bg-white"
@@ -24,22 +25,23 @@ export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProp
             : "반을 선택해주세요."}
         </span>
         <span className="text-[#C4C8CC] text-[12px]">▾</span>
-      </div>
+      </button>
 
       {/* 아래로 펼쳐지는 메뉴 */}
       {open && (
         <div className="absolute left-0 right-0 mt-1 border border-[#DADCE0] rounded-[8px] bg-white shadow z-10">
           {TEAM_OPTIONS.map((team) => (
-            <div
+            <button
               key={team.value}
+              type="button"
               onClick={() => {
                 setTeamName(team.value);
                 setOpen(false);
               }}
-              className="px-3 py-3 text-[14px] text-[#686F75] hover:bg-gray-100 cursor-pointer"
+              className="w-full block text-left px-3 py-3 text-[14px] text-[#686F75] hover:bg-gray-100 cursor-pointer"
             >
               {team.label}
-            </div>
+            </button>
           ))}
         </div>
       )}

--- a/src/components/signup/TeamDropDown.tsx
+++ b/src/components/signup/TeamDropDown.tsx
@@ -1,4 +1,4 @@
-import { TEAM_OPTIONS } from "../../constants/team";
+import { TEAM_OPTIONS } from "@/constants/team";
 import { useState } from "react";
 
 interface TeamDropdownProps {

--- a/src/components/signup/TeamDropDown.tsx
+++ b/src/components/signup/TeamDropDown.tsx
@@ -1,3 +1,4 @@
+import { TEAM_OPTIONS } from "../../constants/team";
 import { useState } from "react";
 
 interface TeamDropdownProps {
@@ -5,20 +6,8 @@ interface TeamDropdownProps {
   setTeamName: (value: string) => void;
 }
 
-interface TeamOption {
-  value: string;
-  label: string;
-}
-
 export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProps) {
-  const [open, setOpen] = useState<boolean>(false);
-
-  const teams: TeamOption[] = [
-    { value: "FRONTEND_FACE", label: "프론트엔드 대면반" },
-    { value: "FRONTEND_NON_FACE", label: "프론트엔드 비대면반" },
-    { value: "BACKEND_FACE", label: "백엔드 대면반" },
-    { value: "BACKEND_NON_FACE", label: "백엔드 비대면반" },
-  ];
+  const [open, setOpen] = useState(false);
 
   return (
     <div className="relative w-full">
@@ -31,7 +20,7 @@ export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProp
       >
         <span className={`text-[14px] ${teamName ? "text-black" : "text-[#C4C8CC]"}`}>
           {teamName
-            ? teams.find((t) => t.value === teamName)?.label
+            ? TEAM_OPTIONS.find((t) => t.value === teamName)?.label
             : "반을 선택해주세요."}
         </span>
         <span className="text-[#C4C8CC] text-[12px]">▾</span>
@@ -40,7 +29,7 @@ export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProp
       {/* 아래로 펼쳐지는 메뉴 */}
       {open && (
         <div className="absolute left-0 right-0 mt-1 border border-[#DADCE0] rounded-[8px] bg-white shadow z-10">
-          {teams.map((team) => (
+          {TEAM_OPTIONS.map((team) => (
             <div
               key={team.value}
               onClick={() => {

--- a/src/components/signup/TeamDropDown.tsx
+++ b/src/components/signup/TeamDropDown.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+
+interface TeamDropdownProps {
+  teamName: string;
+  setTeamName: (value: string) => void;
+}
+
+interface TeamOption {
+  value: string;
+  label: string;
+}
+
+export default function TeamDropdown({ teamName, setTeamName }: TeamDropdownProps) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const teams: TeamOption[] = [
+    { value: "FRONTEND_FACE", label: "프론트엔드 대면반" },
+    { value: "FRONTEND_NON_FACE", label: "프론트엔드 비대면반" },
+    { value: "BACKEND_FACE", label: "백엔드 대면반" },
+    { value: "BACKEND_NON_FACE", label: "백엔드 비대면반" },
+  ];
+
+  return (
+    <div className="relative w-full">
+
+      {/* 선택박스 */}
+      <div
+        onClick={() => setOpen(!open)}
+        className="w-full h-[45px] border border-[#DADCE0] rounded-[8px]
+        px-3 flex items-center justify-between cursor-pointer bg-white"
+      >
+        <span className={`text-[14px] ${teamName ? "text-black" : "text-[#C4C8CC]"}`}>
+          {teamName
+            ? teams.find((t) => t.value === teamName)?.label
+            : "반을 선택해주세요."}
+        </span>
+        <span className="text-[#C4C8CC] text-[12px]">▾</span>
+      </div>
+
+      {/* 아래로 펼쳐지는 메뉴 */}
+      {open && (
+        <div className="absolute left-0 right-0 mt-1 border border-[#DADCE0] rounded-[8px] bg-white shadow z-10">
+          {teams.map((team) => (
+            <div
+              key={team.value}
+              onClick={() => {
+                setTeamName(team.value);
+                setOpen(false);
+              }}
+              className="px-3 py-3 text-[14px] text-[#686F75] hover:bg-gray-100 cursor-pointer"
+            >
+              {team.label}
+            </div>
+          ))}
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -1,0 +1,11 @@
+export interface TeamOption {
+  value: string;
+  label: string;
+}
+
+export const TEAM_OPTIONS: TeamOption[] = [
+  { value: "FRONTEND_FACE", label: "프론트엔드 대면반" },
+  { value: "FRONTEND_NON_FACE", label: "프론트엔드 비대면반" },
+  { value: "BACKEND_FACE", label: "백엔드 대면반" },
+  { value: "BACKEND_NON_FACE", label: "백엔드 비대면반" },
+];

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
-import SlackLoginButton from "../../components/signup/SlackLoginButton";
-import mainLogo from "../../assets/images/main_logo.png";
+import SlackLoginButton from "@/components/signup/SlackLoginButton";
+import mainLogo from "@/assets/images/main_logo.png";
 
 export const SLACK_CLIENT_ID = import.meta.env.VITE_SLACK_CLIENT_ID;
 export const SLACK_REDIRECT_URI = import.meta.env.VITE_SLACK_REDIRECT_URI;

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -1,5 +1,128 @@
-export default function SignUpPage(){
-    return <text>
-        회원 가입 페이지
-    </text>
+import { useState } from "react";
+import TeamDropDown from "../../components/signup/TeamDropDown"
+
+export default function SignUpPage() {
+  const [username, setUsername] = useState("");
+  const [baekjoonId, setBaekjoonId] = useState("");
+  const [teamName, setTeamName] = useState("");
+  const [isAlertAgreed, setIsAlertAgreed] = useState(false);
+
+  return (
+    <div
+      className="
+      min-h-screen flex flex-col items-center justify-center
+      bg-white px-4
+    "
+    >
+      {/* 제목 */}
+      <h1 className="text-[28px] md:text-[32px] font-medium mb-12">
+        회원가입
+      </h1>
+
+      {/* 입력 form 컨테이너 */}
+      <div className="w-full max-w-[380px] flex flex-col gap-8">
+
+        {/* 이름 */}
+        <div className="flex items-center mb-4">
+            <label className="w-[80px] text-[16px] font-medium text-black">
+                이름
+            </label>
+        
+            <div className="relative w-full">
+                <input
+                className="w-full h-[45px] border border-[#DADCE0] rounded-[4px] px-3 pr-10
+                placeholder:text-[#C4C8CC]
+                "
+                placeholder="이름을 입력해주세요."
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                />
+
+                {username && (
+                <button
+                    onClick={() => setUsername("")}
+                    className="
+                    absolute right-3 top-1/2 -translate-y-1/2
+                    w-[16px] h-[16px] bg-[#D5D9DF] rounded-full
+                    flex items-center justify-center text-white text-[10px]
+                    "
+                >
+                    ✕
+                </button>
+                )}
+            </div>
+        </div>
+
+        {/* 백준 ID */}
+        <div className="flex items-center mb-4">
+            <label className="w-[80px] text-[16px] font-medium text-black">
+                백준 ID
+            </label>
+
+            <div className="flex items-center gap-2 w-full">
+                <div className="relative flex-1">
+                <input
+                    className="w-full h-[45px] border border-[#DADCE0] rounded-[4px] px-3 pr-10
+                    placeholder:text-[#C4C8CC]
+                    "
+                    placeholder="백준 ID를 입력해주세요."
+                    value={baekjoonId}
+                    onChange={(e) => setBaekjoonId(e.target.value)}
+                />
+
+                {baekjoonId && (
+                    <button
+                    onClick={() => setBaekjoonId("")}
+                    className="
+                        absolute right-3 top-1/2 -translate-y-1/2
+                        w-[16px] h-[16px] bg-[#D5D9DF] rounded-full
+                        flex items-center justify-center text-white text-[10px]
+                    "
+                    >
+                    ✕
+                    </button>
+                )}
+                </div>
+
+                <button
+                className="
+                    w-[52px] h-[45px] bg-[#45539D] text-white text-[12px] rounded-[4px]
+                "
+                >
+                ID 확인
+                </button>
+            </div>
+        </div>
+
+        {/* 반 */}
+        <div className="flex items-center mb-25">
+            <label className="w-[80px] text-[16px] font-medium text-black">
+                반
+            </label>
+            <TeamDropDown teamName={teamName} setTeamName={setTeamName} />
+        </div>
+
+        <div className="flex flex-col gap-3 mt-14">
+            <label className="flex items-center gap-2 text-[14px] text-[#686F75]">
+                <input
+                type="checkbox"
+                checked={isAlertAgreed}
+                onChange={(e) => setIsAlertAgreed(e.target.checked)}
+                className="w-[18px] h-[18px] border border-[#DADCE0] rounded"
+                />
+                Slack 알림 동의
+            </label>
+
+            <button
+                className="
+                w-full h-[55px] bg-[#45539D] rounded-[8px]
+                text-white font-bold text-[18px]
+                "
+            >
+            완료
+            </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import TeamDropDown from "../../components/signup/TeamDropDown"
+import TeamDropDown from "@/components/signup/TeamDropDown"
 
 export default function SignUpPage() {
   const [username, setUsername] = useState("");

--- a/src/pages/auth/SlackCallbackPage.tsx
+++ b/src/pages/auth/SlackCallbackPage.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+
+export default function SlackCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const code = searchParams.get("code");
+
+  useEffect(() => {
+    if (!code) return;
+
+    const sendCodeToServer = async () => {
+      try {
+        const res = await fetch(`/api/oauth/login?code=${code}`, {
+          method: "GET",
+        });
+
+        const data = await res.json();
+        console.log("서버 응답:", data);
+
+        if (!data.success) {
+          console.log("error")
+          // TODO: 에러 페이지나 로그인 페이지 이동 등의 처리
+          return;
+        }
+
+        const { accessToken, refreshToken, registeredUser } = data.data;
+
+        localStorage.setItem("accessToken", accessToken);
+        localStorage.setItem("refreshToken", refreshToken);
+
+        if (!registeredUser) {
+          navigate("/sign-up", {replace: true})
+        } else {
+          navigate("/main/ranking", {replace: true});
+        }
+
+      } catch (e) {
+        console.error(e);
+        // TODO: 에러처리
+      }
+    };
+
+    sendCodeToServer();
+  }, [code, navigate]);
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h1>Slack Callback</h1>
+      <p>받은 code: {code}</p>
+      <p>로그인 처리 중입니다...</p>
+    </div>
+  );
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -13,7 +13,15 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"noUncheckedSideEffectImports": true
+		"noUncheckedSideEffectImports": true,
+
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"]
+		},
+
+			// JSX 옵션
+		"jsx": "react-jsx"
 	},
-	"include": ["vite.config.ts"]
+	"include": ["src", "vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,18 +3,23 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
-	plugins: [react(),tailwindcss()],
-	server: {
-		port: 3000,
-		proxy: {
-			'/api': {
-				target: 'http://localhost:8080',
-				changeOrigin: true,
-			},
-		},
-	},
-	build: {
-		outDir: 'dist',
-		sourcemap: false,
-	},
+    plugins: [react(), tailwindcss()],
+    resolve: {
+        alias: {
+            "@": new URL("./src", import.meta.url).pathname,
+        },
+    },
+    server: {
+        port: 3000,
+        proxy: {
+            '/api': {
+                target: 'http://localhost:8080',
+                changeOrigin: true,
+            },
+        },
+    },
+    build: {
+        outDir: 'dist',
+        sourcemap: false,
+    },
 });


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- #18 

---

## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

<img width="1105" height="836" alt="스크린샷 2025-12-10 오전 10 31 37" src="https://github.com/user-attachments/assets/875dd150-2836-4c16-b2f3-0bd64750d622" />


- Slack OAuth 인증 후 서버로부터 받은 code를 처리하기 위한 콜백 페이지(SlackCallbackPage) 구현
- Slack OAuth 인증이 완료되면 /oauth/slack/callback 경로로 이동하도록 라우트 추가
- 인증 성공 시 accessToken/refreshToken 저장 및 페이지 이동 처리 (Refresh 토큰 활용한 토큰 재발급 구현 예정)
- 인증 실패 시 에러 대응 처리 구조 추가


---

## ⌨ 기타
